### PR TITLE
fix: remove branch folders case-sensitively

### DIFF
--- a/src/routes/webhook.js
+++ b/src/routes/webhook.js
@@ -36,7 +36,7 @@ const webhook = async (ctx) => {
     return ctx;
   }
 
-  const fullPath = path.join(rootFolder, featureFolder, branchName.toLowerCase());
+  const fullPath = path.join(rootFolder, featureFolder, branchName);
   if (fs.existsSync(fullPath) && !upPathRegex.test(fullPath)) {
     debug(`${ fullPath } seems to exist, will try to delete`);
     fs.removeSync(fullPath);

--- a/tests/webhook.spec.js
+++ b/tests/webhook.spec.js
@@ -18,7 +18,7 @@ const request = supertest.agent(apiUnderTest.listen());
 describe('Reviewly - Webhook', () => {
 
   it('should get the branch from body and delete the folder', (done) => {
-    const branchName = 'branch-name-to-delete';
+    const branchName = 'branch-name-to-delete_MYCS-123';
     const fullPath = path.join(process.env.ROOT_FOLDER, 'features', branchName);
 
     if (!fs.existsSync(fullPath)) {
@@ -40,29 +40,6 @@ describe('Reviewly - Webhook', () => {
       });
   });
 
-  it('should get the branch from body and delete the folder even when branch name is given in uppercase', (done) => {
-    const branchName = 'branchNameToDelete'.toLowerCase();
-    const fullPath = path.join(process.env.ROOT_FOLDER, 'features', branchName);
-
-    if (!fs.existsSync(fullPath)) {
-      fs.mkdirSync(fullPath);
-      fs.writeFileSync(path.join(fullPath, 'index.html'), 'hello world');
-    }
-
-    request
-      .post('/webhook')
-      .set('host', 'mycs.dev')
-      .send({
-        ref: branchName.toUpperCase()
-      })
-      .expect(200, `${ branchName.toUpperCase() } has been deleted`)
-      .end((err) => {
-        if (err) return done(err);
-        if (fs.existsSync(fullPath)) throw new Error('Folder should be deleted');
-        done();
-      });
-  });
-
   it('should not delete subdirectory', (done) => {
     const branchNameWithUpDir = '../../../home/root';
 
@@ -77,7 +54,7 @@ describe('Reviewly - Webhook', () => {
 
   it('should return a message if folder not found', (done) => {
     const folderDoesntExist = 'folderDoesntExist';
-    
+
     request
       .post('/webhook')
       .set('host', 'mycs.dev')


### PR DESCRIPTION
The branches are now uploaded without lower-casing the names, so we need to look for them also without lowercasing.