### PR TITLE
Revert "chore: case-insensitive feature name"

### DIFF
--- a/src/routes/wildcard.js
+++ b/src/routes/wildcard.js
@@ -27,22 +27,21 @@ const featureFolder = config.featureFolder;
  */
 const wildcard = async (ctx) => {
   const host = ctx.req.headers.host.split('.'),
-        featureNameLowCase = host[1].toLowerCase();
-
-  const folderList = utils.getDirectories(path.join(rootFolder, featureFolder));
-  const featureName = folderList.find(item => item.toLowerCase() === featureNameLowCase) || featureNameLowCase;
+        featureName = host[1];
 
   let filePath = ctx.path === '/' ? 'index.html' : ctx.path;
   debug('file requested', path.join(rootFolder, featureFolder, featureName, filePath));
 
   if (!fs.existsSync(path.join(rootFolder, featureFolder, featureName))) {
+    const folderList = utils.getDirectories(path.join(rootFolder, featureFolder));
+
     ctx.type = 'text/html; charset=utf-8';
 
     ctx.body = `This feature-branch was not found, here's what is already deployed on this server<br>`;
     ctx.body += folderList.map((folder) => `<a href="${ utils.buildUrl(host, folder) }">${folder}</a><br>`).join('');
 
     return ctx;
-
+    
   } else if (!fs.existsSync(path.join(rootFolder, featureFolder, featureName, filePath))) {
     debug(path.join(rootFolder, featureFolder, featureName, filePath), ` doesn't exits, we are using index.html`);
 

--- a/tests/features/test_MYCS-123/index.html
+++ b/tests/features/test_MYCS-123/index.html
@@ -1,1 +1,0 @@
-Hello World!

--- a/tests/wildcard.spec.js
+++ b/tests/wildcard.spec.js
@@ -22,13 +22,6 @@ describe('Reviewly', () => {
       .expect(200)
       .expect('Hello World!', done);
   });
-  it('should ignore the case of the feature name', (done) => {
-    request
-      .get('/')
-      .set('host', 'de.test_mycs-123.mycs.dev')
-      .expect(200)
-      .expect('Hello World!', done);
-  });
   it('should return index.html content', (done) => {
     request
       .get('/file-does-not-exist.html')
@@ -41,6 +34,6 @@ describe('Reviewly', () => {
       .get('/')
       .set('host', 'de.EXIST-ME-NOT.hello.dev')
       .expect(200)
-      .expect('This feature-branch was not found, here\'s what is already deployed on this server<br><a href="http://de.stub.hello.dev">stub</a><br><a href="http://de.test_MYCS-123.hello.dev">test_MYCS-123</a><br>', done);
+      .expect('This feature-branch was not found, here\'s what is already deployed on this server<br><a href="http://de.stub.hello.dev">stub</a><br>', done);
   });
 });


### PR DESCRIPTION
Reverts mycsHQ/reviewly#3

Not needed anymore, since we restored lower-casing on the CircleCI side.